### PR TITLE
Fix subpage navigation

### DIFF
--- a/components/FfNavSub.vue
+++ b/components/FfNavSub.vue
@@ -27,10 +27,6 @@ TODO:
 </template>
 
 <script setup lang="ts">
-const { navDirFromPath } = useContentHelpers()
-const route = useRoute()
-const { navigation } = useContent()
-const dir = navDirFromPath(route.path, navigation.value)
-
-const subpagesQuery = queryContent(dir)
+/* extract the basename (first sub-path and query content from there) */
+const subpagesQuery = queryContent(useRoute().path.split("/")[1])
 </script>


### PR DESCRIPTION
We simply need the basename of the first subpage, as this is the nesting level. Then query content from that folder.