### PR TITLE
Address Jon's review comments

### DIFF
--- a/components/FfCards.vue
+++ b/components/FfCards.vue
@@ -6,7 +6,7 @@ A container for cards.
 Style guide reference: Web components/Cards/Card layout
 -->
 <template>
-  <div class="grid grid-cols-1 tablet:grid-cols-2 desktop:grid-cols-3 gap-16">
+  <div class="grid grid-cols-1 tablet:grid-cols-2 desktop:grid-cols-3 gap-24 tablet:gap-32 py-24 tablet:py-48 desktop:py-64">
     <slot></slot>
   </div>
 </template>

--- a/components/FfNavMain.vue
+++ b/components/FfNavMain.vue
@@ -34,7 +34,7 @@ TODO:
 
         <!-- navigation items -->
         <div class="hidden items-center justify-between w-full desktop:flex desktop:w-auto desktop:order-1" id="navbar">
-          <ul class="flex flex-col desktop:px-16 mt-16 desktop:mt-0 space-y-20 desktop:flex-row desktop:space-y-0 desktop:space-x-16 desktop:items-center">
+          <ul class="flex flex-col desktop:px-16 mt-24 desktop:mt-0 space-y-20 desktop:flex-row desktop:space-y-0 desktop:space-x-16 desktop:items-center">
             <li>
               <FfLinkLarge class="block" to="/">Home</FfLinkLarge>
             </li>

--- a/components/FfNavMain.vue
+++ b/components/FfNavMain.vue
@@ -34,7 +34,7 @@ TODO:
 
         <!-- navigation items -->
         <div class="hidden items-center justify-between w-full desktop:flex desktop:w-auto desktop:order-1" id="navbar">
-          <ul class="flex flex-col px-16 mt-16 desktop:mt-0 space-y-20 desktop:flex-row desktop:space-y-0 desktop:space-x-16 desktop:items-center">
+          <ul class="flex flex-col desktop:px-16 mt-16 desktop:mt-0 space-y-20 desktop:flex-row desktop:space-y-0 desktop:space-x-16 desktop:items-center">
             <li>
               <FfLinkLarge class="block" to="/">Home</FfLinkLarge>
             </li>

--- a/components/FfNavSub.vue
+++ b/components/FfNavSub.vue
@@ -6,10 +6,6 @@ Used on section pages that contain child pages.
 Style guide reference: Web components/Navigation/Sub-navigation
 
 TODO:
-- No mobile view implemented (or discussed in style guide). Depending on the
-  amount of navigation items, the horizontal layout is sufficient or too small.
-- Horizontal overflow (which is likely on mobile) breaks the layout by extending
-  the page to the right.
 - The logic to query the subpages is broken.
 -->
 <template>

--- a/components/FfNavSub.vue
+++ b/components/FfNavSub.vue
@@ -8,7 +8,7 @@ Style guide reference: Web components/Navigation/Sub-navigation
 <template>
   <nav class="py-20 font-black text-ultraviolet" v-if="hasSubpages">
     <ContentNavigation v-slot="{ navigation }" :query="subpagesQuery">
-      <ul class="flex flex-col tablet:flex-row tablet:space-x-16 px-0 mx-0">
+      <ul class="flex flex-row flex-wrap gap-16 px-0 mx-0">
         <li class="block" v-for="link of navigation[0].children">
           <FfLinkLarge :key="link._path" :to="link._path">
             {{ link.navTitle || link.title }}

--- a/components/FfNavSub.vue
+++ b/components/FfNavSub.vue
@@ -4,12 +4,9 @@ Sub-navigation
 Used on section pages that contain child pages.
 
 Style guide reference: Web components/Navigation/Sub-navigation
-
-TODO:
-- The logic to query the subpages is broken.
 -->
 <template>
-  <nav class="py-20 font-black text-ultraviolet">
+  <nav class="py-20 font-black text-ultraviolet" v-if="hasSubpages">
     <ContentNavigation v-slot="{ navigation }" :query="subpagesQuery">
       <ul class="flex flex-col tablet:flex-row tablet:space-x-16 px-0 mx-0">
         <li class="block" v-for="link of navigation[0].children">
@@ -23,6 +20,11 @@ TODO:
 </template>
 
 <script setup lang="ts">
-/* extract the basename (first sub-path and query content from there) */
-const subpagesQuery = queryContent(useRoute().path.split("/")[1])
+// Extract the first path segment and use it as "category".
+const category = useRoute().path.split("/")[1]
+const subpagesQuery = queryContent(category)
+
+// A category has at least one page: the index page. Show the subnavigation only
+// if there are more pages than the index page.
+const hasSubpages = (await queryContent(category).count()) > 1
 </script>

--- a/components/FfSectionTop.vue
+++ b/components/FfSectionTop.vue
@@ -10,7 +10,7 @@ Style guide references:
 - Web components/Example web pages/Section top
 -->
 <template>
-  <div class="flex flex-col desktop:flex-row flex-wrap mt-20">
+  <div class="flex flex-col desktop:flex-row flex-wrap">
     <slot></slot>
   </div>
 </template>

--- a/components/FfSectionTopItem.vue
+++ b/components/FfSectionTopItem.vue
@@ -4,12 +4,26 @@ Section top
 The section top presents a summary of the topic with a sub-navigation and
 signposts to child pages in the section.
 
+Use with the "full-width" layout only to have the colored boxes span the full
+width of the screen.
+
 Style guide references:
 - Web components/Example web pages/Section top
 -->
 <template>
-  <div class="basis-1/2 overflow-hidden text-white p-32 desktop:p-64" :class="wrapperClass">
-    <div class="flex-col phone:flex-row flex space-x-16">
+  <div class="group basis-1/2 overflow-hidden text-white p-32 desktop:p-64" :class="wrapperClass">
+    <!-- 1600px/2 - 96px padding == 706px -->
+    <div class="flex flex-col phone:flex-row
+                space-x-16
+                desktop:max-w-[706px]
+                tablet:px-48
+                px-24
+                group-odd:ms-auto group-odd:me-0
+                group-even:ms-0 group-even:me-auto
+                group-odd:tablet:ps-48
+                group-odd:desktop:ps-96
+                group-even:tablet:pe-48
+                group-even:desktop:pe-96">
       <div>
         <component :is="icons[icon]" class="text-[100px] mx-auto" />
       </div>

--- a/content/our-work/0.index.md
+++ b/content/our-work/0.index.md
@@ -1,5 +1,5 @@
 ---
-layout: content
+layout: full-width
 title: What we do
 ---
 

--- a/content/our-work/1.projects.md
+++ b/content/our-work/1.projects.md
@@ -1,5 +1,6 @@
 ---
 title: Our projects
+layout: content
 ---
 
 ::ff-cards{class="mt-64"}

--- a/layouts/full-width.vue
+++ b/layouts/full-width.vue
@@ -1,0 +1,19 @@
+<!--
+Full-width content layout with header.
+
+Use for full-width content pages. Use the "default" layout if no header is
+required.
+-->
+<template>
+  <div class="w-full">
+    <FfHeader />
+    <main>
+      <FfContainer>
+        <FfNavSub />
+      </FfContainer>
+      <FfHeaderTextFrontmatter />
+      <slot />
+    </main>
+    <FfFooter />
+  </div>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -18,7 +18,7 @@ Homepage
     <FfContainer>
       <!--
       TODO: Enable once we have a tools/project listing up.
-      <div class="flex flex-col mb-32 tablet:flex-row">
+      <div class="flex flex-col mb-32 tablet:flex-row py-24 tablet:py-48 desktop:py-64">
         <div class="basis-1/2">
           <IconPhPolygon class="text-ultraviolet mx-auto text-[100px] tablet:text-[150px]" />
         </div>
@@ -35,7 +35,7 @@ Homepage
           <FfBtnCta>Browse Projects</FfBtnCta>
         </div>
       </div>-->
-      <div class="flex flex-col mb-32 tablet:flex-row">
+      <div class="flex flex-col mb-32 tablet:flex-row py-24 tablet:py-48 desktop:py-64">
         <div class="basis-1/2">
           <IconPhUsersThree class="text-ultraviolet mx-auto text-[100px] tablet:text-[150px]" />
         </div>
@@ -53,7 +53,7 @@ Homepage
           <FfBtnCta linkTo="/get-involved">Get involved in open silicon</FfBtnCta>
         </div>
       </div>
-      <div class="flex flex-col mb-32 tablet:flex-row">
+      <div class="flex flex-col mb-32 tablet:flex-row py-24 tablet:py-48 desktop:py-64">
         <div class="basis-1/2">
           <IconPhCpu class="text-ultraviolet mx-auto text-[100px] tablet:text-[150px]" />
         </div>

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -14,30 +14,34 @@ TODO:
   -->
   <NuxtLayout name="default">
     <FfHeaderText title="News from the FOSSi Foundation"/>
+    <!-- Latest (featured) blog post, shown large, if available -->
+    <div v-if="featuredBlogPost" class="bg-pastel-grey">
+      <FfContainer>
+        <ContentRenderer :value="featuredBlogPost" :excerpt="true">
+          <!-- Using the Content blocks/Image & text component. -->
+          <div class="flex flex-col tablet:flex-row my-auto py-24 tablet:py-64">
+            <div class="flex-auto">
+              <NuxtLink :to="featuredBlogPost._path">
+                <FfH2 :href="featuredBlogPost._path">{{ featuredBlogPost.title }}</FfH2>
+                <ContentRendererMarkdown :value="featuredBlogPost" :excerpt="true" />
+
+                <FfLinkUnderline v-if="featuredBlogPost._path" :to="featuredBlogPost._path">Read more ...</FfLinkUnderline>
+              </NuxtLink>
+            </div>
+            <div class="flex-none max-w-[344px] order-first tablet:order-none">
+              <NuxtLink :to="featuredBlogPost._path">
+                <img class="w-max" v-if="featuredBlogPost.coverImage" :src="featuredBlogPost.coverImage"/>
+                <img class="w-max" v-else src="~/assets/images/pattern-guardianship.png"/>
+              </NuxtLink>
+            </div>
+          </div>
+        </ContentRenderer>
+      </FfContainer>
+    </div>
+
     <FfContainer>
-      <!-- Latest (featured) blog post, shown large, if available -->
-      <ContentRenderer v-if="featuredBlogPost" :value="featuredBlogPost" :excerpt="true">
-        <!-- Using the Content blocks/Image & text component. -->
-        <div class="flex flex-col tablet:flex-row my-auto bg-pastel-grey px-24 tablet:px-96 py-24 tablet:py-64 mt-20 tablet:mt-64">
-          <div class="flex-auto">
-            <NuxtLink :to="featuredBlogPost._path">
-              <FfH2 :href="featuredBlogPost._path">{{ featuredBlogPost.title }}</FfH2>
-              <ContentRendererMarkdown :value="featuredBlogPost" :excerpt="true" />
-
-              <FfLinkUnderline v-if="featuredBlogPost._path" :to="featuredBlogPost._path">Read more ...</FfLinkUnderline>
-            </NuxtLink>
-          </div>
-          <div class="flex-none max-w-[344px] order-first tablet:order-none">
-            <NuxtLink :to="featuredBlogPost._path">
-              <img class="w-max" v-if="featuredBlogPost.coverImage" :src="featuredBlogPost.coverImage"/>
-              <img class="w-max" v-else src="~/assets/images/pattern-guardianship.png"/>
-            </NuxtLink>
-          </div>
-        </div>
-      </ContentRenderer>
-
       <!-- A selection of blog posts posts displayed as cards -->
-      <FfCards class="mt-64">
+      <FfCards>
         <FfBlogPostCard v-for="post in blogPosts" :post="post" />
       </FfCards>
     </FfContainer>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,8 +5,6 @@
  ** Default: https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js
  */
 
-import defaultTheme from 'tailwindcss/defaultTheme'
-
 export default {
   theme: {
     extend: {


### PR DESCRIPTION
Address review comments by Jon to address mostly spacing issues.

- Increase vertical padding in large icon signpost
- Card layout: increase whitespace
- Make the section top element full-width
- Cleanup: Remove unused import
- Make featured blog post full-width
- Subnav: Remove outdated TODO comments
- Only show subnavigation if necessary
- Remove the padding-x so that the links line up with the logo
- Mobile nav: Increase margin between logo and items
- Subnavigation: Wrap on demand, even on mobile
