### PR TITLE
Add CORS headers to .well-known content

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,6 +16,11 @@ export default defineNuxtConfig({
     prerender: {
       routes: ['/feed.xml'],
     },
+    routeRules: {
+      // Make the Matrix configuration accessible to clients (and all other
+      // configuration in this directory with it).
+      '/.well-known/**': { cors: true },
+    }
   },
 
   // Make all components in ~/components available for Nuxt Content through its


### PR DESCRIPTION
The .well-known/matrix/client file needs to have CORS headers set. Just
set it for all files in this directory for simplicity.
