### PR TITLE
Setup page for Latch-Up 2024

### DIFF
--- a/components/FfH2.vue
+++ b/components/FfH2.vue
@@ -6,7 +6,7 @@ Style guide references:
 - Web components/Typography/Smaller headings for phone view/h2 phone
 -->
 <template>
-  <h2 class="font-black text-phone-25 tablet:text-36 tracking-tight leading-tighter text-ultraviolet mt-[34px] mb-[22px] tablet:mb-[18px] tablet:mt-[30px] max-w-prose" :id="id">
+  <h2 class="font-black text-phone-25 tablet:text-36 tracking-tight leading-tighter text-ultraviolet pt-[34px] pb-[22px] tablet:pb-[18px] tablet:pt-[30px] max-w-prose" :id="id">
     <ContentSlot :use="$slots.default" unwrap="p" />
   </h2>
 </template>

--- a/components/FfH3.vue
+++ b/components/FfH3.vue
@@ -6,7 +6,7 @@ Style guide references:
 - Web components/Typography/Smaller headings for phone view/h3 phone
 -->
 <template>
-  <h3 class="font-black text-phone-20 tablet:text-24 tracking-tight leading-tighter text-ultraviolet mt-[22px] mb-10 tablet:mt-24 tablet:mb-12 max-w-prose" :id="id">
+  <h3 class="font-black text-phone-20 tablet:text-24 tracking-tight leading-tighter text-ultraviolet pt-[22px] pb-10 tablet:pt-24 tablet:pb-12 max-w-prose" :id="id">
     <ContentSlot :use="$slots.default" unwrap="p" />
   </h3>
 </template>

--- a/components/FfHomepage.vue
+++ b/components/FfHomepage.vue
@@ -70,15 +70,14 @@ Homepage
   <!--
   Event announcement
   -->
-  <!--
   <FfSignpostBanner
     class="bg-[url('/images/banner-orconf.jpg')]"
-    title="Get your dose of FOSSi excitement at ORConf!"
-    subtitle="Join us from Sept 15 to 17 2023 in Munich, Germany for a weekend full of interesting talks, eye-opening hallway discussions, and excitement around free and open source silicon."
-    ctaLabel="Register now for ORConf 2023"
-    ctaTo="/events"
-  />
-  -->
+    title="Get your dose of FOSSi excitement at Latch-Up!"
+    ctaLabel="Register now for Latch-Up 2024"
+    ctaTo="/latch-up/2024"
+  >
+    <p>Join us from April 19 to 21 Boston, MA, USA for a weekend full of interesting talks, eye-opening hallway discussions, and excitement around free and open source silicon.</p>
+  </FfSignpostBanner>
 
   <!--
   News

--- a/components/FfSignpostBanner.vue
+++ b/components/FfSignpostBanner.vue
@@ -13,8 +13,11 @@ Style guide references:
   <div class="text-white bg-cover bg-center">
     <FfContainer class="py-24 tablet:py-48 desktop:py-96">
       <FfH2 class="text-white !mb-16">{{  title }}</FfH2>
-      <FfH3 v-if="subtitle" class="text-white !mb-16 !mt-0">{{ subtitle }}</FfH3>
-      <FfBtnCta inverted class="block w-full tablet:w-auto" :linkTo="ctaTo" :linkTitle="ctaLabel">{{ ctaLabel }}</FfBtnCta>
+      <!-- Apply the styling of FfH3, but to the <p> nodes below it. -->
+      <div class="[&>p]:font-black [&>p]:white [&>p]:text-phone-20 [&>p]:tablet:text-24 [&>p]:tracking-tight [&>p]:leading-tighter [&>p]:text-white [&>p]:mt-[22px] [&>p]:mb-10 [&>p]:tablet:mt-24 [&>p]:tablet:mb-12 [&>p]:max-w-prose">
+        <ContentSlot :use="$slots.default" />
+      </div>
+      <FfBtnCta v-if="ctaTo" inverted class="block w-full tablet:w-auto" :linkTo="ctaTo" :linkTitle="ctaLabel">{{ ctaLabel }}</FfBtnCta>
     </FfContainer>
   </div>
 </template>
@@ -22,10 +25,9 @@ Style guide references:
 <script setup lang="ts">
 defineProps<{
   title: string
-  subtitle?: string
 
   // Call-to-action button
-  ctaLabel: string
-  ctaTo: string
+  ctaLabel?: string
+  ctaTo?: string
 }>()
 </script>

--- a/components/FfSupportingContent.vue
+++ b/components/FfSupportingContent.vue
@@ -1,0 +1,12 @@
+<!--
+Supporting content block
+
+A full-width block with gray background for supporting content.
+-->
+<template>
+  <div class="bg-pastel-grey">
+    <FfContainer class="py-24 tablet:py-64">
+      <ContentSlot :use="$slots.default"/>
+    </FfContainer>
+  </div>
+</template>

--- a/content/events/0.index.md
+++ b/content/events/0.index.md
@@ -21,4 +21,5 @@ we are happy to talk to you.
 
 ## Upcoming events
 
-Next up is **Latch-Up 2024 in the US (location to be announced)**. Learn more about this event at http://latchup.io
+Next up is **Latch-Up 2024**, taking place in **Boston, MA, USA from April 19 - 21**.
+[Learn more and register today!](/latch-up/2024)

--- a/content/latch-up/2024/0.index.md
+++ b/content/latch-up/2024/0.index.md
@@ -1,0 +1,54 @@
+---
+title: Latch-Up 2024
+layout: default
+---
+
+::ff-signpost-banner
+---
+title: Latch-Up 2024
+class: "bg-[url('/images/banner-orconf.jpg')]"
+---
+
+Friday to Sunday April 19&ndash;21, 2024 in Boston, MA, USA
+
+The Latch-Up conference is a weekend of presentations and networking dedicated to free and open source silicon. It's an event for the open source digital design community, much like its European sister conference ORConf, run by the FOSSi Foundation.
+::
+
+
+::ff-supporting-content
+## You are all invited!
+
+The FOSSi Foundation is proud to announce Latch-Up, a conference dedicated to free and open source silicon to be held over the weekend of Friday April 19 to Sunday April 21 in Boston, MA, USA.
+
+Latch-Up is a weekend of presentations and networking for the open source digital design community, much like its European sister conference ORConf.
+
+So save the date, register to attend, and we encourage you to submit a presentation or proposal if you have a project or idea on the topic to share!
+
+Questions? Ping the organizers via [@LatchUpConf](https://twitter.com/LatchUpConf) or send an email to [latch-up@fossi-foundation.org](mailto:latch-up@fossi-foundation.org?subject=something).
+::
+
+
+::ff-container
+
+## Submit a talk
+
+We encourage anybody involved in the open source semiconductor engineering space to come along and share your work or experience. Presentations slots as short as 3 minute lightning-talks and up to 30 minute talks including Q and A are available.
+
+So if you've designed, worked on or even just used open source IP cores and/or management systems, verification IP, build flows, SoCs, simulators, synthesis tools, FPGA and ASIC implementation tools, languages and DSLs, compilers, or anything related we'd love to have you join us to share your experience.
+
+Presentations are submitted through the registration process and we will let you know if your presentation was accepted.
+
+## Registration
+
+Will open soon.
+
+## Sponsoring and volunteering at Latch-Up
+
+Latch-Up is free to attend, but we aim to provide catering and the like during the event. Latch-Up is also a great way to get your company or brand in front of lots of engineers and hackers on the day, and thousands more through recordings of the event. So please [get in touch](mailto:latch-up@fossi-foundation.org) if you'd like to explore sponsorship opportunities.
+
+Latch-Up is organized by volunteers on behalf of the FOSSi Foundation. We are currently looking for more people to help out with arrangements and putting on the event, so please do [email us](mailto:latch-up@fossi-foundation.org) if you would like to volunteer for during the event with setup, AV, or even just local knowledge so we can plan the weekend better.
+
+## Venue
+
+To be announced.
+::

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -159,6 +159,13 @@ export default defineNuxtConfig({
   },
 
   routeRules: {
+    // Redirect the Latch-Up landing page to the most current one.
+    '/latch-up': { redirect: '/latch-up/2024' },
+
+    // Redirect legacy URL to the new dispatcher URL.
+    // (Keep the URL aligned with the conference name "Latch-Up".)
+    '/latchup': { redirect: '/latch-up' },
+
     // Blog posts from pre-2023 website
     '/2015/10/10/welcome': { redirect: '/blog/2015-10-10-welcome' },
     '/2016/01/28/update': { redirect: '/blog/2016-01-28-update' },


### PR DESCRIPTION
Create an event page for Latch-Up 2024.

The design follows https://zeroheight.com/822235964/p/542acd-event-info

- H2/H3: Use padding instead of margin
- FfSignpostBanner: Move from subtitle to a content slot
- Announce Latch-Up 2024
