### PR TITLE
Do not cut off Latch-Up content after the registration form

### DIFF
--- a/content/latch-up/2024/0.index.md
+++ b/content/latch-up/2024/0.index.md
@@ -33,7 +33,7 @@ The FOSSi Foundation is proud to announce Latch-Up, a conference dedicated to fr
 
 Latch-Up is a weekend of presentations and networking for the open source digital design community, much like its European sister conference ORConf.
 
-So save the date, [register to attend](#tickets-and-registration), and we encourage you to submit a presentation or proposal if you have a project or idea on the topic to share!
+So save the date, [register to attend](#tickets-and-registration), and submit a presentation or proposal if you have a project or idea on the topic to share!
 
 Questions? Ping the organizers via [@LatchUpConf](https://twitter.com/LatchUpConf) or send an email to [latch-up@fossi-foundation.org](mailto:latch-up@fossi-foundation.org?subject=something).
 ::
@@ -56,13 +56,13 @@ To help us organizing the event, you are required to :FfEventbriteLink{:eventId=
 **Please register as soon as possible, as we have to close registrations as soon as the room capacity is reached.**
 
 
-**Attendees who are joining us at ORConf on behalf of their company** and/or can claim the conference as professional training expense are encouraged to :FfEventbriteLink{:eventId=eventbriteEventId text="purchase a professional ticket"}.
+**Attendees who are joining us at Latch-Up on behalf of their company** and/or can claim the conference as professional training expense are encouraged to :FfEventbriteLink{:eventId=eventbriteEventId text="purchase a professional ticket"}.
 These ticket sales help us provide all that we do at Latch-Up and keep the event accessible to all members of the community.
 Professional ticket holders are able to get their company name printed on their name badge and receive a special treat.
 
-We ask all ORConf participants to adhere to the the [FOSSi Foundation code of conduct](/code-of-conduct) throughout the event.
+We ask all Latch-Up participants to adhere to the the [FOSSi Foundation code of conduct](/code-of-conduct) throughout the event.
 
-::ff-eventbrite-embedded-checkout{:eventId=eventbriteEventId type="modal" buttonText="Register for Latch-Up 2024"}
+:ff-eventbrite-embedded-checkout{:eventId=eventbriteEventId type="modal" buttonText="Register for Latch-Up 2024"}
 
 ## Sponsoring and volunteering at Latch-Up
 


### PR DESCRIPTION
A syntax error cut off the remaining content in the registration form.
Fix that, together with some other copyediting fixes.
