### PR TITLE
FFCardSignpost: Make the whole card clickable

### DIFF
--- a/components/FfCardSignpost.vue
+++ b/components/FfCardSignpost.vue
@@ -13,15 +13,13 @@ Style guide reference: Web components/Cards/Signpost card
     </div>
     <div class="p-24">
       <FfH3 class="border-b-4 border-ultraviolet">
-        <NuxtLink :to="linkTo" :title="linkTitle" :target="linkTarget" class="text-ultraviolet font-black">{{ headline }}</NuxtLink>
+        {{ headline }}
       </FfH3>
       <FfParaExcerpt v-if="subheading" class="mt-10">
         {{ subheading }}
       </FfParaExcerpt>
       <FfParaExcerpt class="text-warm-black mt-10">
-        <NuxtLink :to="linkTo" :title="linkTitle" :target="linkTarget">
-          <slot></slot>
-        </NuxtLink>
+        <slot></slot>
       </FfParaExcerpt>
     </div>
   </NuxtLink>

--- a/components/FfCardSignpost.vue
+++ b/components/FfCardSignpost.vue
@@ -6,13 +6,11 @@ Use as a signpost to another page or post
 Style guide reference: Web components/Cards/Signpost card
 -->
 <template>
-  <div class="shadow-mid hover:shadow-low bg-white">
-    <NuxtLink :to="linkTo" :title="linkTitle" :target="linkTarget">
-      <div >
-        <NuxtPicture v-if="img" :src="img" height="192" width="500" class="h-[192px] w-full" :class="{ 'object-cover': imgObjectCover, 'object-contain p-10': !imgObjectCover }"/>
-        <NuxtPicture v-else height="192" width="500" class="h-[192px] w-full object-cover" src="/images/pattern-guardianship.png" alt="Pattern: guardianship" />
-      </div>
-    </NuxtLink>
+  <NuxtLink :to="linkTo" :title="linkTitle" :target="linkTarget" class="shadow-mid hover:shadow-low bg-white">
+    <div >
+      <NuxtPicture v-if="img" :src="img" height="192" width="500" class="h-[192px] w-full" :class="{ 'object-cover': imgObjectCover, 'object-contain p-10': !imgObjectCover }"/>
+      <NuxtPicture v-else height="192" width="500" class="h-[192px] w-full object-cover" src="/images/pattern-guardianship.png" alt="Pattern: guardianship" />
+    </div>
     <div class="p-24">
       <FfH3 class="border-b-4 border-ultraviolet">
         <NuxtLink :to="linkTo" :title="linkTitle" :target="linkTarget" class="text-ultraviolet font-black">{{ headline }}</NuxtLink>
@@ -26,7 +24,7 @@ Style guide reference: Web components/Cards/Signpost card
         </NuxtLink>
       </FfParaExcerpt>
     </div>
-  </div>
+  </NuxtLink>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
Fixes: #58 

**Changes made:**
I've replaced the outer "div" container with "NuxtLink". This modification enables users to click anywhere within the content box to access the associated content.

**Screen recording:**

[fix-hover-issue.webm](https://github.com/fossi-foundation/fossi-foundation-web/assets/106796672/3c1e64f8-519d-4445-9d25-0465dad6ce5b)
