### PR TITLE
Use SSR with netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,6 @@
-# Configure Netlify to use Server-Side Generation (SSG), i.e. create static
-# pages and serve it as-is.
+# Use Netlify server-side rendering (SSR).
 [build]
-command = "yarn run nuxi generate"
+command = "yarn build"
 
-# Use Netlify server-side rendering (SSR) instead of server-side generation
-# (SSG) by uncommenting the configuration below.
-#[build]
-#command = "yarn build"
-#[build.environment]
-#NUXT_IMAGE_PROVIDER = "netlify"
+[build.environment]
+NUXT_IMAGE_PROVIDER = "netlifyImageCdn"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -117,26 +117,6 @@ export default defineNuxtConfig({
     // IMPORTANT: No images are served from the assets or public directory.
     // Store all images in content/images instead!
     dir: '.nuxt/content-assets/public',
-
-    // Configure the netlify provider (if it's used).
-    //
-    // `provider: 'netlify'` is set through an environment variable for Netlify
-    // only in netlify.toml.
-    //
-    // The "netlify" provider uses the deprecated Netlify Large Media service
-    // (https://docs.netlify.com/git/large-media/overview/). It's deprecated,
-    // but has no publicly announced end-of-life date yet, so it's still OK to
-    // use until alternatives become available.
-    // As of December 2023, we don't have many alternatives. Static site
-    // generation/SSG (`nuxi generate`) with ipx could work.
-    //
-    // TODO: Maybe support for Netlify Image CDN
-    // (https://docs.netlify.com/image-cdn/overview/) becomes available as
-    // Nuxt Image provider one day, which seems to be the Netlify-suggested
-    // replacement.
-    netlify: {
-      baseUrl: process.env.IMAGES_URL
-    }
   },
 
   app: {


### PR DESCRIPTION


Use SSR (instead of SSG) with netlify and use the new Netlify image CDN
to serve images.

All of that together should significantly reduce generation time and
avoid trip hazards like non-linked pages which aren't pre-rendered.