### PR TITLE
Add direct link to FOSSi Chat space

### DIFF
--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -12,7 +12,7 @@ The Foundation’s goals can be achieved with your support in a couple of ways.
 
 * Developers - setting up our infrastructure takes work and we’re interested in having more people to lend a hand. See our News & Posts section for the latest requests, or contact us at info@fossi-foundation.org to offer your help maintaining and developing our infrastructure.
 
-* Talk. We encourage discussion on all things open source digital design and FOSSi on FOSSi Chat on Matrix. Join the discussion now at https://fossi-chat.org.
+* Talk. We encourage discussion on all things open source digital design and FOSSi on FOSSi Chat on Matrix. Join the discussion now at https://fossi-chat.org. If you already have a Matrix account, you can join directly via [#fossi-chat:fossi-chat.org](https://matrix.to/#/#fossi-chat:fossi-chat.org).
 
 * Individual donations. You can also support us with small donations via Paypal:
 


### PR DESCRIPTION
This PR adds a direct link to the FOSSi Chat space. This is useful if you already have a Matrix account.