### PR TITLE
Add scripting to sync talks to website

### DIFF
--- a/.github/workflows/sync-talks.yml
+++ b/.github/workflows/sync-talks.yml
@@ -1,0 +1,72 @@
+name: Sync conference talks from Google Sheets
+
+# Pulls the talks schedule for one or more conferences from a Google Sheet
+# published to the web (File -> Share -> Publish to web, as CSV) via
+# scripts/sync-talks.mjs, and opens/updates a pull request with the resulting
+# talks.csv whenever it differs from what's on main.
+#
+# To sync an additional (or different) conference, add an entry to
+# scripts/talks-sources.json - see that file for the field descriptions.
+# The same script can be run locally with `node scripts/sync-talks.mjs`.
+
+on:
+  schedule:
+    - cron: '0 * * * *' # hourly
+  workflow_dispatch: {}
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      talks: ${{ steps.read.outputs.talks }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: read
+        run: echo "talks=$(node --print "JSON.stringify(require('./scripts/talks-sources.json'))")" >> "$GITHUB_OUTPUT"
+
+  sync:
+    needs: discover
+    strategy:
+      fail-fast: false
+      matrix:
+        talks: ${{ fromJson(needs.discover.outputs.talks) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Fetch talks CSV
+        run: node scripts/sync-talks.mjs "${{ matrix.talks.name }}"
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git add "${{ matrix.talks.path }}"
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open pull request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "${{ matrix.talks.branch }}"
+          git commit -m "Update ${{ matrix.talks.name }} talks from Google Sheet"
+          git push --force origin "${{ matrix.talks.branch }}"
+
+          if ! gh pr view "${{ matrix.talks.branch }}" >/dev/null 2>&1; then
+            gh pr create \
+              --title "Update ${{ matrix.talks.name }} talks from Google Sheet" \
+              --body "Automated sync from the [talks spreadsheet](${{ matrix.talks.sheetUrl }})." \
+              --head "${{ matrix.talks.branch }}" --base main
+          fi

--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ You can use https://icones.js.org/collection/ph and
 https://icones.js.org/collection/fa6-brands to efficiently search for suitable
 icons.
 
+### Conference talk schedules
+
+Each conference's talk schedule (e.g. `content/orconf/2026/talks.csv`) is kept
+in sync with a Google Sheet that organizers edit. A scheduled GitHub Action
+(`.github/workflows/sync-talks.yml`) fetches each sheet and opens a pull
+request when it changes; you can also run the sync locally with
+`yarn sync-talks`.
+
+To set this up for a new conference:
+
+1. In the Google Sheet, publish the relevant tab to the web as CSV
+   (File > Share > Publish to web).
+2. Add an entry to [`scripts/talks-sources.json`](scripts/talks-sources.json)
+   with the published CSV URL, the sheet's normal edit URL (used in the PR
+   description), the target `talks.csv` path, and a branch name.
+
 ## License
 
 Text content is licensed under CC BY 4.0, "software" (JavaScript, HTML, CSS,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "nuxt build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
-    "preview": "nuxt preview"
+    "preview": "nuxt preview",
+    "sync-talks": "node scripts/sync-talks.mjs"
   },
   "devDependencies": {
     "@iconify-json/fa6-brands": "^1.1.4",

--- a/scripts/sync-talks.mjs
+++ b/scripts/sync-talks.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Fetches each conference's talks schedule from its published Google Sheet
+// (File > Share > Publish to web, as CSV) and writes it to the matching
+// content/**/talks.csv file if it changed. Run with no arguments to sync
+// every conference in talks-sources.json, or pass one or more names to sync
+// only those, e.g.:
+//
+//   node scripts/sync-talks.mjs "ORConf 2026"
+
+import { readFile, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '..')
+
+const sources = JSON.parse(
+  await readFile(path.join(scriptDir, 'talks-sources.json'), 'utf8'),
+)
+
+const requestedNames = process.argv.slice(2)
+const targets = requestedNames.length
+  ? sources.filter((source) => requestedNames.includes(source.name))
+  : sources
+
+if (requestedNames.length) {
+  const found = new Set(targets.map((source) => source.name))
+  const missing = requestedNames.filter((name) => !found.has(name))
+  if (missing.length) {
+    console.error(`Unknown conference name(s): ${missing.join(', ')}`)
+    console.error(`Available: ${sources.map((source) => source.name).join(', ')}`)
+    process.exit(1)
+  }
+}
+
+let hadError = false
+
+for (const source of targets) {
+  process.stdout.write(`${source.name}: fetching... `)
+
+  let csv
+  try {
+    const response = await fetch(source.csvUrl)
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
+    }
+    csv = await response.text()
+  } catch (err) {
+    console.log('FAILED')
+    console.error(`  ${err.message}`)
+    hadError = true
+    continue
+  }
+
+  if (!csv.startsWith('Day,Time,Type,Title')) {
+    console.log('FAILED')
+    console.error(
+      "  Response doesn't look like the talks CSV - check that the sheet is still published to the web (File > Share > Publish to web).",
+    )
+    hadError = true
+    continue
+  }
+
+  const filePath = path.join(repoRoot, source.path)
+  const existing = await readFile(filePath, 'utf8').catch(() => null)
+  if (existing === csv) {
+    console.log('unchanged')
+    continue
+  }
+
+  await writeFile(filePath, csv)
+  console.log(`updated ${source.path}`)
+}
+
+if (hadError) process.exit(1)

--- a/scripts/talks-sources.json
+++ b/scripts/talks-sources.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "ORConf 2026",
+    "csvUrl": "https://docs.google.com/spreadsheets/d/e/2PACX-1vRvawHMHwYRnXHLYB-Y13WzpnhsNhstd5qKA9pQ4CvbALWPr-eP0Hij3fp49mhHLSWzl1IjPn8l6-qJ/pub?gid=1697851936&single=true&output=csv",
+    "sheetUrl": "https://docs.google.com/spreadsheets/d/1DRCoJc12DElo4RlaQGMf792MDaVO8h2WdcwQfdkW5FU/edit?gid=1697851936#gid=1697851936",
+    "path": "content/orconf/2026/talks.csv",
+    "branch": "sync/orconf-2026-talks"
+  }
+]


### PR DESCRIPTION
Copy the CSV from Google Sheets and create a PR to sync the talks CSV
in the repo.

I choose this approach over directly taking the CSV from Google Sheets
because I want a gate between updating the spreadsheet and having it
show on the website.
